### PR TITLE
removed cache testing code

### DIFF
--- a/archnemesis/LineData_0.py
+++ b/archnemesis/LineData_0.py
@@ -618,9 +618,6 @@ class Cache:
         self.n_cache_miss : int = 0
         self._n_max_per_bucket = n_max_per_bucket
         self._buckets = dict()
-        
-        self.TESTING_CACHE_HITS = []
-        self.TESTING_CACHE_MISSES = []
     
     def cache_performance_str(self):
         n_cache_req = self.n_cache_hit + self.n_cache_miss
@@ -631,16 +628,13 @@ class Cache:
         if found_bucket is None:
             self._buckets[bucket] = CachePriorityDataHolder(self._n_max_per_bucket)
             self.n_cache_miss += 1
-            self.TESTING_CACHE_MISSES.append((bucket, identity))
             return None
         
         result = found_bucket.get(identity, default=default)
         if result is None:
             self.n_cache_miss += 1
-            self.TESTING_CACHE_MISSES.append((bucket, identity))
         else:
             self.n_cache_hit += 1
-            self.TESTING_CACHE_HITS.append((bucket, identity))
             _lgr.debug(f'CACHE HIT:: {bucket=} {identity=}')
         
         return result

--- a/tests/test_zzz_forward_models.py
+++ b/tests/test_zzz_forward_models.py
@@ -307,24 +307,6 @@ def test_thermal_emission_realtime_line_by_line():
         plt.legend()
         
         plt.show()
-    
-    # Show cache behaviour
-    if False:
-        line_data = ForwardModel.SpectroscopyX.LINE_DATA[0] # They all share a cache
-        if line_data is not None:
-            print(f'{line_data.cache.cache_performance_str()}')
-            if False:
-                print('')
-                print('## START CACHE HITS ##')
-                for x in line_data.cache.TESTING_CACHE_HITS:
-                    print(f'\t{x}')
-                print('## END CACHE HITS ##')
-                print('')
-                print('## START CACHE MISSES ##')
-                for x in line_data.cache.TESTING_CACHE_MISSES:
-                    print(f'\t{x}')
-                print('## END CACHE MISSES ##')
-    
 
     # Perform comparison
     assert (1-cirsrad_frac_out_of_tolerance) >= required_frac_within_tolerance, (


### PR DESCRIPTION
Some cache testing code was still in place which will eventually fill up RAM by keeping around the identities of each request. This PR deletes that code.